### PR TITLE
Added generation of static routes for slugs

### DIFF
--- a/src/app/arrangementer/[slug]/page.tsx
+++ b/src/app/arrangementer/[slug]/page.tsx
@@ -1,3 +1,14 @@
+// This function is needed for static builing to Github Pages.
+// TODO: When we implement Sanity, change this to fetching all slugs.
+export async function generateStaticParams() {
+  // Manually specify all possible slugs
+  const slugs = ['test'];
+
+  return slugs.map((slug) => ({
+    slug,
+  }));
+}
+
 interface Props {
   params: {
     slug: string;


### PR DESCRIPTION
Trenger denne funksjonen for å generere statiske ruter når vi bygger nettsiden til Github Pages. Denne må endres når vi implementerer Sanity, så har lagt inn en TODO.