### PR TITLE
added feature: does not display events in the past

### DIFF
--- a/src/app/arrangementer/page.tsx
+++ b/src/app/arrangementer/page.tsx
@@ -33,9 +33,17 @@ async function PostPage() {
       </div>
     );
   }
+
+  const today = new Date();
+  const filteredPosts =
+    posts?.filter((post: Post) => {
+      const eventStart = new Date(post.eventStart);
+      return eventStart >= today;
+    }) || [];
+
   return (
     <div>
-      {posts.map((post: Post) => {
+      {filteredPosts.map((post: Post) => {
         const postImageUrl = post.image
           ? urlFor(post.image)?.width(550).height(310).url()
           : null;


### PR DESCRIPTION
Added a filter such that the website does not display events that have already happened. 
They still need to be properly unpublished in Sanity, but at least they won't be shown to the users of the site. 