### PR TITLE
Title of events/posts now wrap and date format changes

### DIFF
--- a/src/app/arrangementer/[slug]/page.tsx
+++ b/src/app/arrangementer/[slug]/page.tsx
@@ -69,7 +69,9 @@ export default async function PostPage({
           </Carousel>
         </div>
 
-        <h1 className="text-4xl font-bold md:mb-1">{post.title}</h1>
+        <h1 className="text-4xl font-bold md:mb-1 text-pretty break-words">
+          {post.title}
+        </h1>
         <p>
           Tidspunkt:{' '}
           {new Date(post.eventStart).toLocaleDateString('nb-NO', {

--- a/src/app/arrangementer/page.tsx
+++ b/src/app/arrangementer/page.tsx
@@ -74,12 +74,12 @@ async function PostPage() {
 
               <div className="">
                 <p>
-                  Publisert:{' '}
-                  {new Date(post.publishedAt).toLocaleDateString('nb-NO')}
-                </p>
-                <p>
                   Tidspunkt:{' '}
-                  {new Date(post.eventStart).toLocaleString('nb-NO', {
+                  {new Date(post.eventStart).toLocaleDateString('nb-NO', {
+                    weekday: 'long',
+                    day: 'numeric',
+                    month: 'long',
+                    year: 'numeric',
                     timeZone: 'Europe/Oslo',
                   })}{' '}
                 </p>

--- a/src/app/stillingsannonser/[slug]/page.tsx
+++ b/src/app/stillingsannonser/[slug]/page.tsx
@@ -46,12 +46,18 @@ export default async function PostPage({
             height="310"
           />
         )}
-        <h1 className="text-4xl font-bold mb-8">{post.title}</h1>
+        <h1 className="text-4xl font-bold mb-8 text-pretty break-words">
+          {post.title}
+        </h1>
         <p>
-          Publisert: {new Date(post.publishedAt).toLocaleDateString('nb-NO')}
-        </p>
-        <p>
-          Søknadsfrist: {new Date(post.eventEnd).toLocaleDateString('nb-NO')}{' '}
+          Søknadsfrist:{' '}
+          {new Date(post.eventStart).toLocaleDateString('nb-NO', {
+            weekday: 'long',
+            day: 'numeric',
+            month: 'long',
+            year: 'numeric',
+            timeZone: 'Europe/Oslo',
+          })}{' '}
         </p>
       </div>
       <div className="prose md:flex md:flex-col md:justify-center md:items-center md:flex-wrap md:text-center md:w-96 md:pt-8">

--- a/src/app/stillingsannonser/page.tsx
+++ b/src/app/stillingsannonser/page.tsx
@@ -65,12 +65,14 @@ async function AnnonsePage() {
 
             <div className="">
               <p>
-                Publisert:{' '}
-                {new Date(post.publishedAt).toLocaleDateString('nb-NO')}
-              </p>
-              <p>
                 Søknadsfrist:{' '}
-                {new Date(post.eventEnd).toLocaleDateString('nb-NO')}{' '}
+                {new Date(post.eventStart).toLocaleDateString('nb-NO', {
+                  weekday: 'long',
+                  day: 'numeric',
+                  month: 'long',
+                  year: 'numeric',
+                  timeZone: 'Europe/Oslo',
+                })}{' '}
               </p>
             </div>
           </div>


### PR DESCRIPTION
Text will now wrap on /arrangementer and /stillingsannonser. 
And changed date format to spell out the month and day of the week.